### PR TITLE
Add a lambdified version of the simulate script

### DIFF
--- a/examples/simulation.py
+++ b/examples/simulation.py
@@ -53,3 +53,21 @@ def simulate(crn, par, initial_cond, start_t, end_t, incr):
                            [initial_cond[s] for s in crn.species],
                            times)
     return dict(zip(crn.species, np.transpose(sol))), times
+
+
+def lambda_simulate(crn, par, initial_cond, start_t, end_t, incr):
+    """Simulate the deterministic dynamics using lambda functions"""
+    # time
+    times = np.arange(start_t, end_t, incr)
+
+    # inserting rate constants in derivatives
+    eqs = [e.subs(par.items()) for e in crn.equations()]
+    
+    # turning sympy equations into lambda functions
+    lam_funcs = list(map(lambda eq: sp.lambdify(crn.species, eq), eqs))
+
+    # integration
+    sol = integrate.odeint(lambda x, t: list(map(lambda func: func(*x), lam_funcs)),
+                           [initial_cond[s] for s in crn.species],
+                           times)
+    return dict(zip(crn.species, np.transpose(sol))), times


### PR DESCRIPTION
I have been using this package for some numerical simulations. I found that some simulations took a while to run. I think the main bottleneck was the use of the `.subs(...).evalf()` method. 

I made a new version of the simulation code to use numpy to handle the evaluation. More information can be found at [Sympy: Numerical Computation](http://docs.sympy.org/latest/modules/numeric-computation.html)

I can make up an example to show off the speed increase if you think that would be useful. 

